### PR TITLE
Work around bug where webkit always reports 0 on document.documentElemen...

### DIFF
--- a/src/common/dom.js
+++ b/src/common/dom.js
@@ -221,7 +221,7 @@ FB.provide('Dom', {
       ? document.documentElement
       : document.body;
     return {
-      scrollTop  : root.scrollTop,
+      scrollTop  : root.scrollTop || document.body.scrollTop,
       scrollLeft : root.scrollLeft,
       width      : self.innerWidth  ? self.innerWidth  : root.clientWidth,
       height     : self.innerHeight ? self.innerHeight : root.clientHeight


### PR DESCRIPTION
Webkit always reports 0 when calling document.documentElement.scrollTop which results in FB.dialogs appearing off screen if the user has scrolled down the page.

This patch resolves this issue, allowing an FB.Dialog to appear centered in the page in webkit even if the user has scrolled down.
